### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Signiant/SigniantAppURLProvider.py
+++ b/Signiant/SigniantAppURLProvider.py
@@ -61,7 +61,7 @@ class SigniantAppURLProvider(URLGetter):
             self.output("Using provided version %s" % version)
         else:
             # Read update xml
-            xml_data = self.download(UPDATE_XML_URL)
+            xml_data = self.download(UPDATE_XML_URL, text=True)
 
             # parse XML data
             try:

--- a/Signiant/SigniantAppURLProvider.py
+++ b/Signiant/SigniantAppURLProvider.py
@@ -19,9 +19,13 @@
 """See docstring for SigniantAppURLProvider class"""
 
 from __future__ import absolute_import
-import urllib2, argparse, sys
-from xml.etree import ElementTree
+
+import argparse
+import sys
+import urllib2
 from distutils.version import LooseVersion
+from xml.etree import ElementTree
+
 from autopkglib import Processor, ProcessorError
 
 UPDATE_XML_URL = "https://updates.signiant.com/signiant_app/signiant-app-info-mac.xml"

--- a/Signiant/SigniantAppURLProvider.py
+++ b/Signiant/SigniantAppURLProvider.py
@@ -65,7 +65,7 @@ class SigniantAppURLProvider(Processor):
                 fref = urllib2.urlopen(UPDATE_XML_URL)
                 xml_data = fref.read()
                 fref.close()
-            except BaseException as err:
+            except Exception as err:
                 raise ProcessorError(
                     "Can't download %s: %s" % (UPDATE_XML_URL, err))
 

--- a/Signiant/SigniantAppURLProvider.py
+++ b/Signiant/SigniantAppURLProvider.py
@@ -18,6 +18,7 @@
 
 """See docstring for SigniantAppURLProvider class"""
 
+from __future__ import absolute_import
 import urllib2, argparse, sys
 from xml.etree import ElementTree
 from distutils.version import LooseVersion
@@ -67,7 +68,7 @@ class SigniantAppURLProvider(Processor):
             # parse XML data
             try:
                 root = ElementTree.fromstring(xml_data)
-            except (OSError, IOError, ElementTree.ParseError), err:
+            except (OSError, IOError, ElementTree.ParseError) as err:
                 raise Exception("Can't read %s: %s" % (xml_data, err))
 
             # extract version number from the XML


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including using the HEAD method for specific requests in SigniantAppURLProvider.py), but this should catch the low-hanging fruit right now.